### PR TITLE
2026 01 clout fixes

### DIFF
--- a/Setup_35_NZ.php
+++ b/Setup_35_NZ.php
@@ -22,8 +22,8 @@ $tourDetElabTeam		= '0'; // 0:Standard, 1:Field, 2:3DI
 $tourDetElimination		= '0'; // 0: No Eliminations, 1: Elimination Allowed
 $tourDetGolds			= '9s';
 $tourDetXNine			= '7s';
-$tourDetGoldsChars		= 'H';
-$tourDetXNineChars		= 'J';
+$tourDetGoldsChars		= 'J';
+$tourDetXNineChars		= 'H';
 $tourDetDouble			= '0';
 $DistanceInfoArray=array(array(6,6));
 

--- a/Setup_35_NZ.php
+++ b/Setup_35_NZ.php
@@ -22,8 +22,8 @@ $tourDetElabTeam		= '0'; // 0:Standard, 1:Field, 2:3DI
 $tourDetElimination		= '0'; // 0: No Eliminations, 1: Elimination Allowed
 $tourDetGolds			= '9s';
 $tourDetXNine			= '7s';
-$tourDetGoldsChars		= '9';
-$tourDetXNineChars		= '7';
+$tourDetGoldsChars		= 'H';
+$tourDetXNineChars		= 'J';
 $tourDetDouble			= '0';
 $DistanceInfoArray=array(array(6,6));
 


### PR DESCRIPTION
Fix applied to correct the value attributes for the 9s and 7s in the Tournament advanced parameters to correct the issue with tie-breaker values of 9s and 7s count-back not working.